### PR TITLE
Add TOCs to longer articles

### DIFF
--- a/articles/five-ways-to-add-partitions.md
+++ b/articles/five-ways-to-add-partitions.md
@@ -11,11 +11,11 @@ Coming from traditional databases to Athena can be a little bit confusing. In mo
 
 There are at least five ways you can add partitions to Athena. Technically, all but one boil down to the same thing under the hood, but they can still be more or less convenient to use in different situations. Here are the five:
 
-* Partition projection
-* Using SQL with Athena
-* MSCK REPAIR TABLE
-* Using the Glue Data Catalog API
-* Using a Glue Crawler
+* [Partition projection](#partition-projection)
+* [Using SQL with Athena](#using-sql-with-athena)
+* [MSCK REPAIR TABLE](#msck-repair-table)
+* [Using the Glue Data Catalog API](#using-the-glue-data-catalog-api)
+* [Using a Glue Crawler](#glue-crawlers)
 
 ## Partition Projection
 

--- a/articles/unnest-arrays-to-rows.md
+++ b/articles/unnest-arrays-to-rows.md
@@ -11,6 +11,8 @@ This makes it possible to do pretty advanced things, but it's not always easy to
 
 In data formats like JSON it's very common to have arrays and map properties, and one question that often comes up is how you flatten these structures to work better in a traditional tabular format – in other words, how to turn array elements into rows. The answer is the [`UNNEST`][1] operator.
 
+In this article I will cover [how to flatten arrays to rows](#unnesting-arrays), [how to flatten maps to rows](#unnesting-maps), but also [when you should be using `UNNEST`](#when-to-unnest).
+
 ## Unnesting arrays
 
 `UNNEST` is a bit peculiar as it is is an operator that produces a relation, unlike most functions which transform or aggregate scalar values.

--- a/articles/working-with-csv.md
+++ b/articles/working-with-csv.md
@@ -9,6 +9,8 @@ CSV could be the most common data interchange format there is, and since it's al
 
 Athena unsurprisingly has good support for reading CSV data, but it's not always easy to know what you should use as there are multiple implementations with completely different features and ways of configuration.
 
+In this article I will cover how to use the [default CSV implementation](#the-default-implementation), what do do when you have [quoted fields](#quoted-fields), how to [skip headers](#skipping-header-lines), how to deal with [NULL and empty fields](#empty-fields-and-null-values), how [types are interpreted](#type-conversion), [column names and column order](#column-names-and-order), as well as [general guidance](#which-one-to-use).
+
 ## The default implementation
 
 The component in Athena that is responsible for reading and parsing data is called a serde, short for serializer/deserializer. If you don't specify anything else when creating an Athena table you get a serde called [`LazySimpleSerDe`][1], which was made for delimited text such as CSV. It can be configured for different delimiters, escape characters, and line endings, among other things.


### PR DESCRIPTION
I've added automatic anchors to [article headers in the Markdown rendering](https://github.com/iconara/athena-guide-site/pull/5), so that the longer articles can have TOCs and links down into the content in their introduction sections.

This adds TOC paragraphs to the three long articles.